### PR TITLE
fix & feat : Mainfest 수정 및 MainActivity 버튼 추가, GalleryAcitivity 권한 설정 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,10 +3,11 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
-        <entry key="app/src/main/res/layout/activity_gallery.xml" value="0.25" />
+        <entry key="app/src/main/res/layout/activity_gallery.xml" value="0.340625" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2625" />
         <entry key="app/src/main/res/layout/activity_photo.xml" value="0.37395833333333334" />
         <entry key="app/src/main/res/layout/color_square.xml" value="0.2625" />
+        <entry key="app/src/main/res/layout/gallery_square.xml" value="0.340625" />
       </map>
     </option>
   </component>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,10 +28,8 @@
 
         </activity>
         <activity
-            android:name=".MainActivity"
-            android:exported="false" >
-
-        </activity>
+            android:name=".step3.gallery.GalleryActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/photos/MainActivity.kt
+++ b/app/src/main/java/com/example/photos/MainActivity.kt
@@ -8,6 +8,7 @@ import android.widget.Button
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.photos.databinding.ActivityMainBinding
+import com.example.photos.step3.gallery.GalleryActivity
 import kotlin.random.Random
 
 class MainActivity : AppCompatActivity() {
@@ -29,8 +30,13 @@ class MainActivity : AppCompatActivity() {
         binding.recycler.clipChildren = false
         binding.recycler.addItemDecoration(ItemDecoration())
 
-        binding.button.setOnClickListener {
+        binding.buttonPermission.setOnClickListener {
             val intent = Intent(this, PhotoActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.buttonGallery.setOnClickListener {
+            val intent = Intent(this, GalleryActivity::class.java)
             startActivity(intent)
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,22 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintlayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <Button
-        android:id="@+id/button"
-        android:layout_width="match_parent"
+        android:id="@+id/button_permission"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Button" />
+        android:text="@string/permission"
+        app:layout_constraintEnd_toStartOf="@+id/button_gallery"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/button_gallery"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/gallery"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/button_permission"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" >
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button_gallery">
 
     </androidx.recyclerview.widget.RecyclerView>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/gallery_square.xml
+++ b/app/src/main/res/layout/gallery_square.xml
@@ -3,5 +3,5 @@
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/imageView"
-    android:layout_width="80dp"
-    android:layout_height="80dp" />
+    android:layout_width="100dp"
+    android:layout_height="100dp" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="app_name">Photos</string>
     <string name="top_app_toolbar">Photos</string>
+    <string name="permission">Permission</string>
+    <string name="gallery">Gallery</string>
 </resources>


### PR DESCRIPTION
#12 부분 구현

- [x] 원격 저장소를 pull 받는 과정에서 Mainfest 에 MainActivity 가 2개 설정된 오류 해결
- [x] MainActivity 에서 PermissionActivity, GalleryActivity 로 이동하는 버튼 추가 (변경하는 과정에서 LinearLayout -> ConstraintLayout 으로 변경)
- [x] GalleryActivity에 권한 설정 구현 (승인 시 앨범에 바로 접근, 1번 거절 시 권한 접근이 필요하다는 메세지 전달, 2번 거절 시 환경설정으로 이동)

https://user-images.githubusercontent.com/79504043/159628655-78c74149-de44-4fb1-832f-ee4ee7dc112c.mov


