### PR TITLE
[wooki & 스타크] AppBar +버튼 추가 및 화면 전환

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,11 +3,14 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="app/src/main/res/layout/activity_doodles.xml" value="0.37395833333333334" />
         <entry key="app/src/main/res/layout/activity_gallery.xml" value="0.340625" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2625" />
         <entry key="app/src/main/res/layout/activity_photo.xml" value="0.37395833333333334" />
         <entry key="app/src/main/res/layout/color_square.xml" value="0.2625" />
         <entry key="app/src/main/res/layout/gallery_square.xml" value="0.340625" />
+        <entry key="app/src/main/res/menu-v26/gallery_appbar_menu.xml" value="0.37395833333333334" />
+        <entry key="app/src/main/res/menu/gallery_appbar_menu.xml" value="0.3682051282051282" />
       </map>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,13 +3,14 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
-        <entry key="app/src/main/res/layout/activity_doodles.xml" value="0.37395833333333334" />
-        <entry key="app/src/main/res/layout/activity_gallery.xml" value="0.340625" />
+        <entry key="app/src/main/res/layout/activity_doodles.xml" value="0.32425742574257427" />
+        <entry key="app/src/main/res/layout/activity_gallery.xml" value="0.1" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2625" />
         <entry key="app/src/main/res/layout/activity_photo.xml" value="0.37395833333333334" />
         <entry key="app/src/main/res/layout/color_square.xml" value="0.2625" />
         <entry key="app/src/main/res/layout/gallery_square.xml" value="0.340625" />
         <entry key="app/src/main/res/menu-v26/gallery_appbar_menu.xml" value="0.37395833333333334" />
+        <entry key="app/src/main/res/menu/doodles_appbar_menu.xml" value="0.37395833333333334" />
         <entry key="app/src/main/res/menu/gallery_appbar_menu.xml" value="0.3682051282051282" />
       </map>
     </option>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.photos" >
+    package="com.example.photos">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
@@ -13,7 +13,10 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppCompat.Light.NoActionBar" >
+        android:theme="@style/Theme.AppCompat.Light.NoActionBar">
+        <activity
+            android:name=".step3.gallery.DoodlesActivity"
+            android:exported="false" />
         <activity
             android:name=".PhotoActivity"
             android:exported="false" />
@@ -25,7 +28,6 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
         </activity>
         <activity
             android:name=".step3.gallery.GalleryActivity"

--- a/app/src/main/java/com/example/photos/step3/gallery/DoodlesActivity.kt
+++ b/app/src/main/java/com/example/photos/step3/gallery/DoodlesActivity.kt
@@ -1,0 +1,18 @@
+package com.example.photos.step3.gallery
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.example.photos.databinding.ActivityDoodlesBinding
+
+class DoodlesActivity : AppCompatActivity() {
+
+    private val binding by lazy {
+        ActivityDoodlesBinding.inflate(layoutInflater)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+    }
+}

--- a/app/src/main/java/com/example/photos/step3/gallery/DoodlesActivity.kt
+++ b/app/src/main/java/com/example/photos/step3/gallery/DoodlesActivity.kt
@@ -2,6 +2,8 @@ package com.example.photos.step3.gallery
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.MenuItem
+import com.example.photos.R
 import com.example.photos.databinding.ActivityDoodlesBinding
 
 class DoodlesActivity : AppCompatActivity() {
@@ -14,5 +16,19 @@ class DoodlesActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        val toolbar = binding.doodlesTopAppToolbar
+        setSupportActionBar(toolbar)
+
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> {
+                finish()
+                return true
+            }
+        }
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/example/photos/step3/gallery/GalleryActivity.kt
+++ b/app/src/main/java/com/example/photos/step3/gallery/GalleryActivity.kt
@@ -8,14 +8,13 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.provider.MediaStore
 import android.provider.Settings
-import android.util.Log
+import android.view.Menu
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.app.ActivityCompat
+import androidx.core.view.get
 import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.RecyclerView
+import com.example.photos.PhotoActivity
 import com.example.photos.R
 import com.example.photos.databinding.ActivityGalleryBinding
-import com.example.photos.databinding.ActivityPhotoBinding
 import com.example.photos.step3.model.Image
 import com.google.android.material.snackbar.Snackbar
 
@@ -67,6 +66,22 @@ class GalleryActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         requestPermissionLauncher.launch(REQUIRED_PERMISSIONS)
+        val menu = binding.topAppToolbar.menu[0]
+        menu.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.plus_icon -> {
+                    val intent = Intent(this, DoodlesActivity::class.java)
+                    startActivity(intent)
+                    true
+                }
+                else -> false
+            }
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.gallery_appbar_menu, menu)
+        return true
     }
 
     private fun getAllImagePathInStorage(): List<Image> {

--- a/app/src/main/java/com/example/photos/step3/gallery/GalleryActivity.kt
+++ b/app/src/main/java/com/example/photos/step3/gallery/GalleryActivity.kt
@@ -66,8 +66,8 @@ class GalleryActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         requestPermissionLauncher.launch(REQUIRED_PERMISSIONS)
-        val menu = binding.topAppToolbar.menu[0]
-        menu.setOnMenuItemClickListener { menuItem ->
+        val plusButton = binding.galleryTopAppToolbar.menu[0]
+        plusButton.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.plus_icon -> {
                     val intent = Intent(this, DoodlesActivity::class.java)

--- a/app/src/main/res/drawable/ic_baseline_add_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_add_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_close_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_close_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/activity_doodles.xml
+++ b/app/src/main/res/layout/activity_doodles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".step3.gallery.DoodlesActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_doodles.xml
+++ b/app/src/main/res/layout/activity_doodles.xml
@@ -1,9 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".step3.gallery.DoodlesActivity">
+    android:layout_height="match_parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/doodles_topAppToolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/white"
+            app:title="Doodles"
+            app:navigationIcon="@drawable/ic_baseline_close_24" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_gallery.xml
+++ b/app/src/main/res/layout/activity_gallery.xml
@@ -14,7 +14,8 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="@color/white"
-            app:title="@string/top_app_toolbar" />
+            app:title="@string/top_app_toolbar"
+            app:menu="@menu/gallery_appbar_menu" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/app/src/main/res/layout/activity_gallery.xml
+++ b/app/src/main/res/layout/activity_gallery.xml
@@ -10,7 +10,7 @@
         android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/topAppToolbar"
+            android:id="@+id/gallery_topAppToolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="@color/white"

--- a/app/src/main/res/menu/doodles_appbar_menu.xml
+++ b/app/src/main/res/menu/doodles_appbar_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/plus_icon"
+        android:title="@string/close_icon"
+        android:icon="@drawable/ic_baseline_close_24"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/menu/gallery_appbar_menu.xml
+++ b/app/src/main/res/menu/gallery_appbar_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/plus_icon"
+        android:title="@string/addicon"
+        android:icon="@drawable/ic_baseline_add_24"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="permission">Permission</string>
     <string name="gallery">Gallery</string>
     <string name="addicon">AddIcon</string>
+    <string name="close_icon">close_icon</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="top_app_toolbar">Photos</string>
     <string name="permission">Permission</string>
     <string name="gallery">Gallery</string>
+    <string name="addicon">AddIcon</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.Photos" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.Photos" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
@@ -12,5 +12,6 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="actionModeCloseDrawable">@drawable/ic_baseline_close_24</item>
     </style>
 </resources>


### PR DESCRIPTION
- [x] AppBar에 +버튼을 추가한다.
- [x] (add) 버튼을 누르면 다른 화면으로 전환 기능 구현
- [x] 새로운 화면은 다음과 같이 설정하고 구현
   - AppBar Title을 명시
   - Close 동작을 하는 버튼을 추가하고, 이전 화면으로 돌아가는 동작을 구현
  
**+ 버튼을 눌러서 Doodles Activity 로 이동하는 동작 코드**
```kotlin
        val plusButton = binding.galleryTopAppToolbar.menu[0]
        plusButton.setOnMenuItemClickListener { menuItem ->
            when (menuItem.itemId) {
                R.id.plus_icon -> {
                    val intent = Intent(this, DoodlesActivity::class.java)
                    startActivity(intent)
                    true
                }
                else -> false
            }
        }
```

**x 버튼을 눌러서 뒤로가기 동작을 실행하는 코드**
```kotlin
    override fun onOptionsItemSelected(item: MenuItem): Boolean {
        when (item.itemId) {
            android.R.id.home -> {
                finish()
                return true
            }
        }
        return super.onOptionsItemSelected(item)
    }
```

### 동작예시 

https://user-images.githubusercontent.com/79504043/159862623-29670c67-0af8-4c8c-88f0-b500233b5b45.mov


